### PR TITLE
Added one more example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ by the method
 With this method you can build a mock in the way you are used to build a
 PHPUnit mock:
 
+## Examples
+1. Test built-in function with mocked results within same namespace.
 ```php
 <?php
 
-namespace foo;
+namespace Foo;
 
 class BuiltinTest extends \PHPUnit\Framework\TestCase
 {
@@ -56,6 +58,74 @@ class BuiltinTest extends \PHPUnit\Framework\TestCase
     }
 }
 ```
+
+2. When class to be tested and the test class are in different namespace.
+
+```php
+<?php
+// Source class to be tested
+namespace Foo;
+ 
+class TimeClass
+{
+    public function oneHourAgo()
+    {
+        return date('H:i:s', time() - 3600);
+    }
+}
+```
+```php
+<?php
+// Tests for TimeClass
+namespace Tests\Foo;
+ 
+use PHPUnit\Framework\TestCase;
+ 
+class TimeClassTest extends TestCase
+{
+    use \phpmock\phpunit\PHPMock;
+
+    /**
+     * @var TimeClass
+     */
+    private $timeClass;
+ 
+    /**
+     * Create test subject before test
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->timeClass = new TimeClass();
+    }
+    
+    protected function tearDown()
+    {
+        this->timeClass = null;
+        parent::tearDown();
+    }
+ 
+    /*
+     * Test cases
+     */
+    public function testOneHourAgoFromNoon()
+    {
+        $time = $this->getFunctionMock('\\Foo', 'time');
+        $time->expects($this->once())->willReturn(strtotime('12:00'));
+
+        $this->assertEquals('11:00', $this->timeClass->oneHourAgo());
+    }
+    
+    public function testOneHourAgoFromMidnight()
+    {
+        $time = $this->getFunctionMock('\\Foo', 'time');
+        $time->expects($this->once())->willReturn(strtotime('0:00'));
+
+        $this->assertEquals('23:00', $this->timeClass->oneHourAgo());
+    }
+}
+```
+
 
 There's no need to disable the mocked function. The PHPUnit integration does
 that for you.


### PR DESCRIPTION
@malkusch, thanks for this great tool for mocking built-in functions.  I've also read the same article Fabien wrote before finding your repo.  But I don't like his example because I always prefer to have my unit tests be under a `Tests` namespace contrary to the source class that should be under its own namespace.  So I'm thrilled that you made the namespace an argument of the `getFunctionMock` function that solved my issue.
With that said, I thought it would be nice and probably clearer for anyone that comes to your repo to have more than one example so they can see what your tool can do.
Here's my proposed change to the README.  BTW, I didn't test the example I added although they should work but I did test your tool with some real unit tests and they are working as expected.  Please let me know if this looks good to you.  Many thanks.