### PR TITLE
Update __phpunit_verify() method signature for PHPUnit 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - PHPUNIT_VERSION=~7.1.0
   - PHPUNIT_VERSION=~7.2.0
   - PHPUNIT_VERSION=~7.3.0
+  - PHPUNIT_VERSION=~7.4.0
 
 php:
   - 7.2
@@ -30,6 +31,8 @@ matrix:
   exclude:
     - php: 7
       env: PHPUNIT_VERSION=dev-master
+    - php: 7
+      env: PHPUNIT_VERSION=~7.4.0
     - php: 7
       env: PHPUNIT_VERSION=~7.3.0
     - php: 7

--- a/classes/MockObjectProxy.php
+++ b/classes/MockObjectProxy.php
@@ -56,10 +56,10 @@ class MockObjectProxy implements MockObject
      * @SuppressWarnings(PHPMD)
      */
     // @codingStandardsIgnoreStart
-    public function __phpunit_verify()
+    public function __phpunit_verify(bool $unsetInvocationMocker = true)
     {
         // @codingStandardsIgnoreEnd
-        return $this->mockObject->__phpunit_verify();
+        return $this->mockObject->__phpunit_verify($unsetInvocationMocker);
     }
 
     public function expects(Invocation $matcher)

--- a/tests/MockObjectProxyTest.php
+++ b/tests/MockObjectProxyTest.php
@@ -96,7 +96,7 @@ class MockObjectProxyTest extends TestCase
         return [
             ["__phpunit_getInvocationMocker"],
             ["__phpunit_setOriginalObject", ["bar"]],
-            ["__phpunit_verify"],
+            ["__phpunit_verify", [true]],
         ];
     }
 }


### PR DESCRIPTION
PHPUnit 7.4 has added a parameter to the public interface which breaks implementation compatibility when missing.
This change should not affect PHPUnit <7.3 when having the parameter in the implementation but not the interface.

Fixes #29 