### PR TITLE
Fixes PHPUnit 8.4 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.phpunit.result.cache
+vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
 
 env:
   - PHPUNIT_VERSION=dev-master
+  - PHPUNIT_VERSION=~8.4.0
+  - PHPUNIT_VERSION=~8.3.0
   - PHPUNIT_VERSION=~8.2.0
   - PHPUNIT_VERSION=~8.1.0
   - PHPUNIT_VERSION=~8.0.0
@@ -37,6 +39,10 @@ matrix:
     - php: 7.1
       env: PHPUNIT_VERSION=dev-master
     - php: 7.1
+      env: PHPUNIT_VERSION=~8.4.0
+    - php: 7.1
+      env: PHPUNIT_VERSION=~8.3.0
+    - php: 7.1
       env: PHPUNIT_VERSION=~8.2.0
     - php: 7.1
       env: PHPUNIT_VERSION=~8.1.0
@@ -44,6 +50,10 @@ matrix:
       env: PHPUNIT_VERSION=~8.0.0
     - php: 7
       env: PHPUNIT_VERSION=dev-master
+    - php: 7
+      env: PHPUNIT_VERSION=~8.4.0
+    - php: 7
+      env: PHPUNIT_VERSION=~8.3.0
     - php: 7
       env: PHPUNIT_VERSION=~8.2.0
     - php: 7

--- a/autoload.php
+++ b/autoload.php
@@ -1,6 +1,12 @@
 <?php
 
-if (! interface_exists(\PHPUnit\Framework\MockObject\Matcher\Invocation::class)) {
+if (class_exists(\PHPUnit\Framework\MockObject\Rule\InvocationOrder::class)) {
+    class_alias(
+        \PHPUnit\Framework\MockObject\Rule\InvocationOrder::class,
+        \PHPUnit\Framework\MockObject\Matcher\Invocation::class
+    );
+}
+elseif (! interface_exists(\PHPUnit\Framework\MockObject\Matcher\Invocation::class)) {
     class_alias(
         \PHPUnit_Framework_MockObject_Matcher_Invocation::class,
         \PHPUnit\Framework\MockObject\Matcher\Invocation::class
@@ -30,6 +36,13 @@ if (! class_exists(\PHPUnit\Framework\MockObject\Builder\InvocationMocker::class
     );
 }
 
+if (class_exists(\PHPUnit\Framework\MockObject\Rule\MethodName::class)) {
+    class_alias(
+        \PHPUnit\Framework\MockObject\Rule\MethodName::class,
+        \PHPUnit\Framework\MockObject\Matcher\MethodName::class
+    );
+}
+
 if (! class_exists(\PHPUnit\Framework\MockObject\Matcher\MethodName::class)) {
     class_alias(
         \PHPUnit_Framework_MockObject_Matcher_MethodName::class,
@@ -37,14 +50,16 @@ if (! class_exists(\PHPUnit\Framework\MockObject\Matcher\MethodName::class)) {
     );
 }
 
-if (! interface_exists(\PHPUnit\Framework\MockObject\Stub\MatcherCollection::class)) {
+if (!class_exists(\PHPUnit\Framework\MockObject\InvocationHandler::class)
+    && !interface_exists(\PHPUnit\Framework\MockObject\Stub\MatcherCollection::class)) {
     class_alias(
         \PHPUnit_Framework_MockObject_Stub_MatcherCollection::class,
         \PHPUnit\Framework\MockObject\Stub\MatcherCollection::class
     );
 }
 
-if (! class_exists(\PHPUnit\Framework\MockObject\InvocationMocker::class)) {
+if (!class_exists(\PHPUnit\Framework\MockObject\InvocationHandler::class)
+    && !class_exists(\PHPUnit\Framework\MockObject\InvocationMocker::class)) {
     class_alias(
         \PHPUnit_Framework_MockObject_InvocationMocker::class,
         \PHPUnit\Framework\MockObject\InvocationMocker::class
@@ -65,6 +80,11 @@ if (! class_exists(\PHPUnit\Framework\BaseTestListener::class)) {
 }
 
 if (class_exists(\PHPUnit\Runner\Version::class)
+    && version_compare(\PHPUnit\Runner\Version::id(), '8.4.0') >= 0
+) {
+    class_alias(\phpmock\phpunit\DefaultArgumentRemoverReturnTypes84::class, \phpmock\phpunit\DefaultArgumentRemover::class);
+    class_alias(\phpmock\phpunit\MockObjectProxyReturnTypes84::class, \phpmock\phpunit\MockObjectProxy::class);
+} elseif (class_exists(\PHPUnit\Runner\Version::class)
     && version_compare(\PHPUnit\Runner\Version::id(), '8.1.0') >= 0
 ) {
     class_alias(\phpmock\phpunit\DefaultArgumentRemoverReturnTypes::class, \phpmock\phpunit\DefaultArgumentRemover::class);

--- a/classes/DefaultArgumentRemoverReturnTypes84.php
+++ b/classes/DefaultArgumentRemoverReturnTypes84.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace phpmock\phpunit;
+
+use phpmock\generator\MockFunctionGenerator;
+use PHPUnit\Framework\MockObject\Invocation;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+
+/**
+ * Removes default arguments from the invocation.
+ *
+ * @author Markus Malkusch <markus@malkusch.de>
+ * @link bitcoin:1335STSwu9hST4vcMRppEPgENMHD2r1REK Donations
+ * @license http://www.wtfpl.net/txt/copying/ WTFPL
+ * @internal
+ */
+class DefaultArgumentRemoverReturnTypes84 extends InvocationOrder
+{
+    /**
+     * @SuppressWarnings(PHPMD)
+     */
+    public function invokedDo(Invocation $invocation)
+    {
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD)
+     */
+    public function matches(Invocation $invocation) : bool
+    {
+        $iClass = class_exists(Invocation::class);
+
+        if ($invocation instanceof Invocation\StaticInvocation
+            || $iClass
+        ) {
+            $this->removeDefaultArguments(
+                $invocation,
+                $iClass ? Invocation::class : Invocation\StaticInvocation::class
+            );
+        } else {
+            MockFunctionGenerator::removeDefaultArguments($invocation->parameters);
+        }
+
+        return false;
+    }
+
+    public function verify() : void
+    {
+    }
+
+    /**
+     * This method is not defined in the interface, but used in
+     * PHPUnit_Framework_MockObject_InvocationMocker::hasMatchers().
+     *
+     * @return boolean
+     * @see \PHPUnit_Framework_MockObject_InvocationMocker::hasMatchers()
+     */
+    public function hasMatchers()
+    {
+        return false;
+    }
+
+    public function toString() : string
+    {
+        return __CLASS__;
+    }
+
+    /**
+     * Remove default arguments from StaticInvocation or its children (hack)
+     *
+     * @SuppressWarnings(PHPMD)
+     */
+    private function removeDefaultArguments(Invocation $invocation, string $class)
+    {
+        $remover = function () {
+            MockFunctionGenerator::removeDefaultArguments($this->parameters);
+        };
+
+        $remover->bindTo($invocation, $class)();
+    }
+}

--- a/classes/MockObjectProxyReturnTypes84.php
+++ b/classes/MockObjectProxyReturnTypes84.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace phpmock\phpunit;
+
+use PHPUnit\Framework\MockObject\Builder\InvocationMocker as BuilderInvocationMocker;
+use PHPUnit\Framework\MockObject\InvocationHandler;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+use PHPUnit\Framework\MockObject\MockObject;
+use phpmock\integration\MockDelegateFunctionBuilder;
+
+/**
+ * Proxy for PHPUnit's PHPUnit_Framework_MockObject_MockObject.
+ *
+ * @author Markus Malkusch <markus@malkusch.de>
+ * @link bitcoin:1335STSwu9hST4vcMRppEPgENMHD2r1REK Donations
+ * @license http://www.wtfpl.net/txt/copying/ WTFPL
+ * @internal
+ */
+class MockObjectProxyReturnTypes84 implements MockObject
+{
+
+    /**
+     * @var MockObject $mockObject The mock object.
+     */
+    private $mockObject;
+
+    /**
+     * Inject the subject.
+     *
+     * @param MockObject $mockObject   The subject.
+     */
+    public function __construct(MockObject $mockObject)
+    {
+        $this->mockObject = $mockObject;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD)
+     */
+    // @codingStandardsIgnoreStart
+    public function __phpunit_getInvocationHandler(): InvocationHandler
+    {
+        return $this->mockObject->__phpunit_getInvocationHandler();
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD)
+     */
+    // @codingStandardsIgnoreStart
+    public function __phpunit_setOriginalObject($originalObject) : void
+    {
+        // @codingStandardsIgnoreEnd
+        $this->mockObject->__phpunit_setOriginalObject($originalObject);
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD)
+     */
+    // @codingStandardsIgnoreStart
+    public function __phpunit_verify(bool $unsetInvocationMocker = true) : void
+    {
+        // @codingStandardsIgnoreEnd
+        $this->mockObject->__phpunit_verify($unsetInvocationMocker);
+    }
+
+    public function expects(InvocationOrder $matcher) : BuilderInvocationMocker
+    {
+        return $this->mockObject->expects($matcher)->method(MockDelegateFunctionBuilder::METHOD);
+    }
+
+    /**
+     * This method is not part of the contract but was found in
+     * PHPUnit's mocked_class.tpl.dist.
+     *
+     * @SuppressWarnings(PHPMD)
+     */
+    // @codingStandardsIgnoreStart
+    public function __phpunit_hasMatchers() : bool
+    {
+        // @codingStandardsIgnoreEnd
+        return $this->mockObject->__phpunit_hasMatchers();
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD)
+     */
+    // @codingStandardsIgnoreStart
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration) : void
+    {
+        // @codingStandardsIgnoreEnd
+        $this->mockObject->__phpunit_setReturnValueGeneration($returnValueGeneration);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=7",
-        "phpunit/phpunit": "^6 || ^7 || ^8",
+        "phpunit/phpunit": "8.4.x-dev",
         "php-mock/php-mock-integration": "^2"
     },
     "archive": {

--- a/tests/PHPMockTest.php
+++ b/tests/PHPMockTest.php
@@ -17,22 +17,22 @@ class PHPMockTest extends AbstractMockTest
 {
 
     use PHPMock;
-    
+
     protected function defineFunction($namespace, $functionName)
     {
         self::defineFunctionMock($namespace, $functionName);
     }
-    
+
     protected function mockFunction($namespace, $functionName, callable $function)
     {
         $mock = $this->getFunctionMock($namespace, $functionName);
         $mock->expects($this->any())->willReturnCallback($function);
     }
-    
+
     protected function disableMocks()
     {
     }
-    
+
     /**
      * Tests building a mock with arguments.
      *
@@ -42,10 +42,10 @@ class PHPMockTest extends AbstractMockTest
     {
         $time = $this->getFunctionMock(__NAMESPACE__, "sqrt");
         $time->expects($this->once())->with(9)->willReturn(2);
-        
+
         $this->assertEquals(2, sqrt(9));
     }
-    
+
     /**
      * Tests failing an expectation.
      *


### PR DESCRIPTION
Closes #39

Fixes things to run under PHPUnit 8.4 with all tests passing with the exception of a warning on `phpmock\phpunit\PHPMockTest::testBackupStaticAttributes` due to https://github.com/sebastianbergmann/phpunit/issues/3879.

I've extended Travis-CI to test against PHPUnit 8.3 and 8.4 as well.