### PR TITLE
Require phpspec/prophecy as dev dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,7 +243,7 @@ jobs:
     name: PHPUnit ${{ matrix.phpunit-version }} on PHP ${{ matrix.php-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php-mock/php-mock-integration": "^2.1"
     },
     "require-dev": {
-        "phpspec/prophecy": "^1.15"
+        "phpspec/prophecy": "^1.10.3"
     },
     "archive": {
         "exclude": ["/tests"]

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,8 @@
     },
     "archive": {
         "exclude": ["/tests"]
+    },
+    "require-dev": {
+        "phpspec/prophecy": "^1.15"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "phpunit/phpunit": "^6 || ^7 || ^8 || ^9",
         "php-mock/php-mock-integration": "^2.1"
     },
-    "archive": {
-        "exclude": ["/tests"]
-    },
     "require-dev": {
         "phpspec/prophecy": "^1.15"
+    },
+    "archive": {
+        "exclude": ["/tests"]
     }
 }


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit/issues/5033 changed phpunit
to no longer depend on phpspec/prophecy. This results in the need to add
a development dependency for phpspec/prophecy. Doing so results in a
warning, since PHPUnit\Framework\TestCase::prophesize() is deprecated
and will be removed in PHPUnit 10. While we could use the trait provided
by phpspec/prophecy-phpunit instead, it would break PHP < 7.3 support.

* Closes #50