### PR TITLE
fix: PHPUnit 10.0.17 compatibility

### DIFF
--- a/classes/PHPMock.php
+++ b/classes/PHPMock.php
@@ -100,7 +100,7 @@ trait PHPMock
         if (class_exists(Facade::class)) {
             $property = new ReflectionProperty(Facade::class, 'sealed');
             $property->setAccessible(true);
-            $property->setValue(false);
+            $property->setValue(Facade::instance(), false);
 
             Facade::registerSubscriber(
                 new MockDisabler($deactivatable)

--- a/classes/PHPMock.php
+++ b/classes/PHPMock.php
@@ -98,15 +98,17 @@ trait PHPMock
     public function registerForTearDown(Deactivatable $deactivatable)
     {
         if (class_exists(Facade::class)) {
+            $facade = Facade::instance();
+
             $property = new ReflectionProperty(Facade::class, 'sealed');
             $property->setAccessible(true);
-            $property->setValue(Facade::instance(), false);
+            $property->setValue($facade, false);
 
-            Facade::instance()->registerSubscriber(
+            $facade->registerSubscriber(
                 new MockDisabler($deactivatable)
             );
 
-            $property->setValue(true);
+            $property->setValue($facade, true);
 
             return;
         }

--- a/classes/PHPMock.php
+++ b/classes/PHPMock.php
@@ -102,7 +102,7 @@ trait PHPMock
             $property->setAccessible(true);
             $property->setValue(Facade::instance(), false);
 
-            Facade::registerSubscriber(
+            Facade::instance()->registerSubscriber(
                 new MockDisabler($deactivatable)
             );
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=7",
-        "phpunit/phpunit": "^6 || ^7 || ^8 || ^9 || ^10",
+        "phpunit/phpunit": "^6 || ^7 || ^8 || ^9 || ^10.0.17",
         "php-mock/php-mock-integration": "^2.2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Changes due to changes in PHPUnit Facade, as `sealed` is no longer a static property.

Since PHPUnit 10.0.17

Ref: https://github.com/sebastianbergmann/phpunit/compare/10.0.16...10.0.17#diff-ab19a10fe89766492d38ba76cd277de3a187c605adb9e06be1b6a893540a1908