### PR TITLE
feat: Clean-up listener/subscriber after the test

### DIFF
--- a/classes/MockDisablerPHPUnit10.php
+++ b/classes/MockDisablerPHPUnit10.php
@@ -22,15 +22,22 @@ class MockDisablerPHPUnit10 implements FinishedSubscriber
      * @var Deactivatable The function mocks.
      */
     private $deactivatable;
+
+    /**
+     * @var callable|null The callback to execute after the test.
+     */
+    private $callback;
     
     /**
      * Sets the function mocks.
      *
      * @param Deactivatable $deactivatable The function mocks.
+     * @param callback|null $callback      The callback to execute after the test.
      */
-    public function __construct(Deactivatable $deactivatable)
+    public function __construct(Deactivatable $deactivatable, ?callable $callback = null)
     {
         $this->deactivatable = $deactivatable;
+        $this->callback = $callback;
     }
 
     /**
@@ -39,10 +46,16 @@ class MockDisablerPHPUnit10 implements FinishedSubscriber
     public function notify(Finished $event) : void
     {
         $this->deactivatable->disable();
+        if ($this->callback !== null) {
+            call_user_func($this->callback, $this);
+        }
     }
 
     public function endTest(): void
     {
         $this->deactivatable->disable();
+        if ($this->callback !== null) {
+            call_user_func($this->callback, $this);
+        }
     }
 }

--- a/classes/MockDisablerPHPUnit10.php
+++ b/classes/MockDisablerPHPUnit10.php
@@ -2,6 +2,7 @@
 
 namespace phpmock\phpunit;
 
+use Closure;
 use phpmock\Deactivatable;
 use PHPUnit\Event\Test\Finished;
 use PHPUnit\Event\Test\FinishedSubscriber;
@@ -24,7 +25,7 @@ class MockDisablerPHPUnit10 implements FinishedSubscriber
     private $deactivatable;
 
     /**
-     * @var callable|null The callback to execute after the test.
+     * @var Closure|null The callback to execute after the test.
      */
     private $callback;
     
@@ -32,9 +33,9 @@ class MockDisablerPHPUnit10 implements FinishedSubscriber
      * Sets the function mocks.
      *
      * @param Deactivatable $deactivatable The function mocks.
-     * @param callback|null $callback      The callback to execute after the test.
+     * @param Closure|null $callback       The callback to execute after the test.
      */
-    public function __construct(Deactivatable $deactivatable, ?callable $callback = null)
+    public function __construct(Deactivatable $deactivatable, ?Closure $callback = null)
     {
         $this->deactivatable = $deactivatable;
         $this->callback = $callback;
@@ -47,7 +48,7 @@ class MockDisablerPHPUnit10 implements FinishedSubscriber
     {
         $this->deactivatable->disable();
         if ($this->callback !== null) {
-            call_user_func($this->callback, $this);
+            ($this->callback)($this);
         }
     }
 
@@ -55,7 +56,7 @@ class MockDisablerPHPUnit10 implements FinishedSubscriber
     {
         $this->deactivatable->disable();
         if ($this->callback !== null) {
-            call_user_func($this->callback, $this);
+            ($this->callback)($this);
         }
     }
 }

--- a/classes/MockDisablerPHPUnit6.php
+++ b/classes/MockDisablerPHPUnit6.php
@@ -2,6 +2,7 @@
 
 namespace phpmock\phpunit;
 
+use Closure;
 use phpmock\Deactivatable;
 use PHPUnit\Framework\BaseTestListener;
 use PHPUnit\Framework\Test;
@@ -24,7 +25,7 @@ class MockDisablerPHPUnit6 extends BaseTestListener
     private $deactivatable;
 
     /**
-     * @var callable|null The callback to execute after the test.
+     * @var Closure|null The callback to execute after the test.
      */
     private $callback;
     
@@ -32,9 +33,9 @@ class MockDisablerPHPUnit6 extends BaseTestListener
      * Sets the function mocks.
      *
      * @param Deactivatable $deactivatable The function mocks.
-     * @param callable|null $callback      The callback to execute after the test.
+     * @param Closure|null $callback       The callback to execute after the test.
      */
-    public function __construct(Deactivatable $deactivatable, callable $callback = null)
+    public function __construct(Deactivatable $deactivatable, Closure $callback = null)
     {
         $this->deactivatable = $deactivatable;
         $this->callback = $callback;
@@ -54,7 +55,7 @@ class MockDisablerPHPUnit6 extends BaseTestListener
         
         $this->deactivatable->disable();
         if ($this->callback !== null) {
-            call_user_func($this->callback, $this);
+            ($this->callback)($this);
         }
     }
 }

--- a/classes/MockDisablerPHPUnit6.php
+++ b/classes/MockDisablerPHPUnit6.php
@@ -22,15 +22,22 @@ class MockDisablerPHPUnit6 extends BaseTestListener
      * @var Deactivatable The function mocks.
      */
     private $deactivatable;
+
+    /**
+     * @var callable|null The callback to execute after the test.
+     */
+    private $callback;
     
     /**
      * Sets the function mocks.
      *
      * @param Deactivatable $deactivatable The function mocks.
+     * @param callable|null $callback      The callback to execute after the test.
      */
-    public function __construct(Deactivatable $deactivatable)
+    public function __construct(Deactivatable $deactivatable, callable $callback = null)
     {
         $this->deactivatable = $deactivatable;
+        $this->callback = $callback;
     }
     
     /**
@@ -46,5 +53,8 @@ class MockDisablerPHPUnit6 extends BaseTestListener
         parent::endTest($test, $time);
         
         $this->deactivatable->disable();
+        if ($this->callback !== null) {
+            call_user_func($this->callback, $this);
+        }
     }
 }

--- a/classes/MockDisablerPHPUnit7.php
+++ b/classes/MockDisablerPHPUnit7.php
@@ -22,15 +22,22 @@ class MockDisablerPHPUnit7 extends BaseTestListener
      * @var Deactivatable The function mocks.
      */
     private $deactivatable;
+
+    /**
+     * @var callable|null The callback to execute after the test.
+     */
+    private $callback;
     
     /**
      * Sets the function mocks.
      *
      * @param Deactivatable $deactivatable The function mocks.
+     * @param callable|null $callback      The callback to execute after the test.
      */
-    public function __construct(Deactivatable $deactivatable)
+    public function __construct(Deactivatable $deactivatable, $callback = null)
     {
         $this->deactivatable = $deactivatable;
+        $this->callback = $callback;
     }
     
     /**
@@ -46,5 +53,8 @@ class MockDisablerPHPUnit7 extends BaseTestListener
         parent::endTest($test, $time);
         
         $this->deactivatable->disable();
+        if ($this->callback !== null) {
+            call_user_func($this->callback, $this);
+        }
     }
 }

--- a/classes/MockDisablerPHPUnit7.php
+++ b/classes/MockDisablerPHPUnit7.php
@@ -2,6 +2,7 @@
 
 namespace phpmock\phpunit;
 
+use Closure;
 use phpmock\Deactivatable;
 use PHPUnit\Framework\BaseTestListener;
 use PHPUnit\Framework\Test;
@@ -24,7 +25,7 @@ class MockDisablerPHPUnit7 extends BaseTestListener
     private $deactivatable;
 
     /**
-     * @var callable|null The callback to execute after the test.
+     * @var Closure|null The callback to execute after the test.
      */
     private $callback;
     
@@ -32,9 +33,9 @@ class MockDisablerPHPUnit7 extends BaseTestListener
      * Sets the function mocks.
      *
      * @param Deactivatable $deactivatable The function mocks.
-     * @param callable|null $callback      The callback to execute after the test.
+     * @param Closure|null $callback       The callback to execute after the test.
      */
-    public function __construct(Deactivatable $deactivatable, $callback = null)
+    public function __construct(Deactivatable $deactivatable, Closure $callback = null)
     {
         $this->deactivatable = $deactivatable;
         $this->callback = $callback;
@@ -54,7 +55,7 @@ class MockDisablerPHPUnit7 extends BaseTestListener
         
         $this->deactivatable->disable();
         if ($this->callback !== null) {
-            call_user_func($this->callback, $this);
+            ($this->callback)($this);
         }
     }
 }

--- a/classes/PHPMock.php
+++ b/classes/PHPMock.php
@@ -7,6 +7,7 @@ use phpmock\integration\MockDelegateFunctionBuilder;
 use phpmock\MockBuilder;
 use phpmock\Deactivatable;
 use PHPUnit\Event\Facade;
+use PHPUnit\Event\Test\Finished;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 use ReflectionMethod;
@@ -135,9 +136,9 @@ trait PHPMock
                     static function (MockDisabler $original) use ($directDispatcher, $propSubscribers) {
                         $subscribers = $propSubscribers->getValue($directDispatcher);
 
-                        foreach ($subscribers['PHPUnit\Event\Test\Finished'] as $key => $subscriber) {
+                        foreach ($subscribers[Finished::class] as $key => $subscriber) {
                             if ($original === $subscriber) {
-                                unset($subscribers['PHPUnit\Event\Test\Finished'][$key]);
+                                unset($subscribers[Finished::class][$key]);
                             }
                         }
 

--- a/tests/MockDisablerTest.php
+++ b/tests/MockDisablerTest.php
@@ -2,6 +2,7 @@
 
 namespace phpmock\phpunit;
 
+use phpmock\Deactivatable;
 use phpmock\Mock;
 use PHPUnit\Framework\TestCase;
 
@@ -31,5 +32,23 @@ class MockDisablerTest extends TestCase
         $disabler->endTest($this, 1);
         
         $this->assertEquals(1, min(1, 9));
+    }
+
+    public function testCallback()
+    {
+        $executed = false;
+        $executedWith = null;
+        $mock = $this->createMock(Deactivatable::class);
+        $disabler = new MockDisabler($mock, static function ($disabler) use (&$executed, &$executedWith) {
+            self::assertInstanceOf(MockDisabler::class, $disabler);
+
+            $executed = true;
+            $executedWith = $disabler;
+        });
+
+        $disabler->endTest($this, 1);
+
+        self::assertTrue($executed);
+        self::assertSame($executedWith, $disabler);
     }
 }


### PR DESCRIPTION
Fixes #74

Now `MockDisabler` constructor has optional 2nd parameter `callback` which will be executed once the test ends.
We remove the listener (for old PHPUnit versions) and for newer - remove the subscriber.  It stills heavily relies on the internals of PHPUnit and it might break at any point, but as so the whole package.

Tests are a bit tricky, basically we chain of three tests, so I do not need to register a mock function in set up.
First just register a mock and it should be clearer in tearDown;
so then, the second should have the counter === 1, as the mock has been disabled, and it should be removed at this point, so the 3rd test should remain with the same counter (=== 1) - and actually it was failing before before the 'callback' solution.