### PR TITLE
Update PHP_CodeSniffer version in workflow

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -20,7 +20,7 @@ jobs:
           tools: composer:v2, cs2pr
 
       - name: Install dependencies
-        run: composer require squizlabs/php_codesniffer --no-interaction --no-progress
+        run: composer require squizlabs/php_codesniffer "^3" --no-interaction --no-progress
 
       - name: "Run phpcs"
         run: vendor/bin/phpcs -q --standard=PSR2 classes/ tests/ --report=checkstyle | cs2pr


### PR DESCRIPTION
Keep using v3 as it was not causing any errors on PSR2 in the repo. We need investigate more why v4 is failing here.