### PR TITLE
fix: PHPUnit 13.0.1 tests

### DIFF
--- a/tests/MockObjectProxyTest.php
+++ b/tests/MockObjectProxyTest.php
@@ -60,7 +60,7 @@ class MockObjectProxyTest extends TestCase
         if (class_exists(\PHPUnit\Runner\Version::class)
             && version_compare(\PHPUnit\Runner\Version::id(), '8.4.0') >= 0
         ) {
-            $invocationHandler = new InvocationHandler([$methods], false);
+            $invocationHandler = new InvocationHandler([$methods], false, true);
             $invocationMocker = $invocationHandler->expects($matcher);
         } else {
             $invocationMocker = new InvocationMocker(


### PR DESCRIPTION
As of https://github.com/sebastianbergmann/phpunit/releases/tag/13.0.1 `InvocationHandler` returns now `InvocationStubber` for stubs instead of `InvocationMocker`

See https://github.com/sebastianbergmann/phpunit/issues/6497